### PR TITLE
Better mounted check

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,13 +60,13 @@ define mounts (
           ensure_resource('file', $dirtree, {'ensure' => 'directory'})
 
           exec { "/bin/mount '${dest}'":
-            unless  => "/bin/mount -l | /bin/grep '${dest}'",
+            unless  => "/bin/mount -l | /bin/grep ' on ${dest} type '",
             require => [File[$dirtree], Fstab["fstab entry for ${source} to ${dest} as ${type}"]],
           }
         }
         'absent': {
           exec { "/bin/umount '${dest}'":
-            onlyif => "/bin/mount -l | /bin/grep '${dest}'",
+            onlyif => "/bin/mount -l | /bin/grep ' on ${dest} type '",
             before => Fstab["fstab entry for ${source} to ${dest} as ${type}"],
           }
 


### PR DESCRIPTION
The previous check would fail to properly detect if things weren't mounted,
especially if the NFS server and the mount point shared a common name (e.g.
/home or something).
