### PR TITLE
change case from operatingsystem to osfamily

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,8 +21,8 @@ define mounts (
     err('The type parameter is required.')
   }
 
-  case $::operatingsystem {
-    redhat, centos, amazon: {
+  case $::osfamily {
+    RedHat: {
 
       fstab { "fstab entry for ${source} to ${dest} as ${type}":
         ensure => $ensure,


### PR DESCRIPTION
This is to encompass OracleLinux operatingsystem as well, which falls
under the RedHat osfamily.

This addresses issue #12 

Change-Id: I034f6cc28b298551b1d60ba375bdb1f480121d56
